### PR TITLE
Improved hint functionality

### DIFF
--- a/Unicog/unicog/app/Mahjong/Js/layout.js
+++ b/Unicog/unicog/app/Mahjong/Js/layout.js
@@ -14,6 +14,9 @@ class Layout {
         this.numChildren = gameSession.layout.header.numChildren
         this.layers = []
         this.roots = []
+        
+        this.activeHintTile1 = null
+        this.activeHintTile2 = null
     }
     /**
      * Adds a layer to the layers array.
@@ -118,7 +121,7 @@ class Layout {
                 if (this.findNeighbours(tilenode.children[i]).length < 2) {
                     tilenode.children[i].selectable = true
                     if (gameSession.beginnerMode) {
-                        tilenode.children[i].unhighlightTile()
+                        tilenode.children[i].resetTileHighlight()
                     }
                 }
             }
@@ -128,7 +131,7 @@ class Layout {
         if (neighbours.length > 0 && neighbours[0].parents.length === 0) {
             neighbours[0].selectable = true
             if (gameSession.beginnerMode) {
-                neighbours[0].unhighlightTile()
+                neighbours[0].resetTileHighlight()
             }
             
         }
@@ -396,12 +399,27 @@ class Layout {
             for (var j = 0; j < nodeList.length; j++) {
                 if (nodeList[j].tile.texture.key === this.roots[i].tile.texture.key) {
                     console.log("Found match")
-                    nodeList[j].highlightTile(0x5c95f2)
-                    this.roots[i].highlightTile(0x5c95f2)
+                    nodeList[j].highlightTileHint()
+                    this.roots[i].highlightTileHint()
+                    this.activeHintTile1 = nodeList[j]
+                    this.activeHintTile2 = this.roots[i]
                     return
-                } 
+                }
             }
             nodeList.push(this.roots[i])
+        }
+    }
+    /**
+     * Unhighlights any remaining tiles from an active hint.
+     */
+    removeHint () {
+        if (this.activeHintTile1 !== null) {
+            this.activeHintTile1.removeHint()
+            this.activeHintTile1 = null
+        }
+        if (this.activeHintTile2 !== null) {
+            this.activeHintTile2.removeHint()
+            this.activeHintTile2 = null
         }
     }
     /**

--- a/Unicog/unicog/app/Mahjong/Js/tilenode.js
+++ b/Unicog/unicog/app/Mahjong/Js/tilenode.js
@@ -19,6 +19,7 @@ class TileNode {
         this.children = [],
         this.tile = null,
         this.selectable = false
+        this.hintActive = false
     }
     /**
      * Sets the sprite tint to a hexadecimal color. This color by default is off-yellow (0xFFFD9A)
@@ -31,15 +32,43 @@ class TileNode {
         this.tile.setTint(tint)
     }
     /**
-     * removes the sprite tint. This will return the tint color to white.
+     * Resets the sprite tint. This will return the tint color to white, or blue if the tile is part
+     * of an active hint.
      *
+     * @param {number} hint - The hexadecimal value used to tint the sprite
      * @see Board.selectTile()
      */
-    unhighlightTile () {
+    resetTileHighlight (hint = 0x5c95f2) {
+        if (this.hintActive) {
+            this.highlightTileHint(hint)
+        } else {
+            this.tile.clearTint()
+        }
+    }
+    /**
+     * Sets the sprite tint to a hexadecimal color. This color by default is a blue (0x5c95f2).
+     * This method also marks the tile as being part of an active hint.
+     *
+     * @param {number} hint - The hexadecimal value used to tint the sprite
+     * @see Layout.giveHint()
+     * @see TileNode.highlightTile(tint)
+     */
+    highlightTileHint (hint = 0x5c95f2) {
+        this.hintActive = true
+        this.tile.setTint(hint)
+    }
+    /**
+     * Removes the sprite tint. This will return the tint color to white.
+     * This method also marks the tile as being part of an active hint.
+     *
+     * @see Layout.removeHint()
+     */
+    removeHint () {
+        this.hintActive = false
         this.tile.clearTint()
     }
     /**
-     * Sets the sprite tint to a hexadecimal color. This color by default is a grey (0x808080)
+     * Sets the sprite tint to a hexadecimal color. This color by default is a grey (0x808080).
      * This method functions the same as highlightTile but defaults to a different color for clarity.
      *
      * @param {number} dim - The hexadecimal value used to tint the sprite
@@ -49,7 +78,6 @@ class TileNode {
     dimTile (dim = 0x808080) {
         this.tile.setTint(dim)
     }
-    
     /**
      * Sets the sprite position of the TileNode to be centered on the screen in the correct layout position.
      * The sprite is also scaled to the session scale parameter 


### PR DESCRIPTION
- Hint button appearance and sound now occurs after the incorrect match delay, not as soon as the incorrect match is made (which means the sounds no longer overlap).
- Selecting then unselecting a hint tile no longer removes the blue tint. Blue tint is restored when the tile is unselected to preserve the hint.
- Making any match (whether it involves both, one of, or none of the hint tiles) now removes the blue tint from any remaining hint tiles, as the user has made a match. It is therefore now impossible to have more than two tiles at once tinted blue.
- Since the hint tinting persists until any match is made, any additional hint buttons are prevented from appearing again while a hint is already in play (since the hint will always suggest the current hint, so it's useless to hit the button again).

Edit:

- Also, clicking the hint button deselects the selected tile if there is one.